### PR TITLE
Fix arm64ec library linking

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,23 +8,24 @@ fn main() {
 #[cfg(all(target_os = "windows", target_env = "msvc"))]
 fn add_spectre_link_search() {
     use cc::windows_registry;
-    use std::{env, path::Path};
+    use std::env;
 
     let target = env::var("TARGET").expect("missing TARGET");
     let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("missing CARGO_CFG_TARGET_ARCH");
     let arch = match arch.as_str() {
         "x86_64" => "x64",
         "x86" => "x86",
-        "aarch64" => "arm64",
+        // The spectre\arm64ec directory doesn't have any libs in it, instead the spectre arm64 libs
+        // contain both arm64 and arm64ec objects.
+        "aarch64" | "arm64ec" => "arm64",
         "arm" => "arm32",
-        "arm64ec" => "arm64ec",
         _ => panic!("unsupported arch: {arch}"),
     };
 
     let tool = windows_registry::find_tool(&target, "cl.exe").expect("couldn't find cl.exe");
     let spectre_libs = tool.path().join(format!(r"..\..\..\..\lib\spectre\{arch}"));
 
-    if Path::new(&spectre_libs).exists() {
+    if spectre_libs.exists() {
         println!(
             "cargo:rustc-link-search=native={}",
             spectre_libs.into_os_string().into_string().unwrap()


### PR DESCRIPTION
Note that arm64 *.lib files contain arm64ec *.obj files.

Our arm64ec windows rust builds failed BinSkim checks even after including this dependency.

After some investigation I found out that arm64ec spectre library fold does not have any *.lib files.

I first tried linking against x64 since arm64ec is for x64 compatibility but linker fails. Then I tried linking with arm64 spectre libraries and it succeeds.

You can see that arm64 spectre *.lib files contain arm64ec compilation units. Take libcmt.lib for example:
1. open dev console
2. `lib.exe /LIST %VCToolsInstallDir%lib\spectre\arm64\libcmt.lib | findstr arm64ec`

Step 2 for x64 *.lib files give empty results.